### PR TITLE
Add COPY instruction to support case insensitivity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,2 @@
 FROM mysql/mysql-server:5.5
+COPY my.cnf /etc/mysql/my.cnf

--- a/README.md
+++ b/README.md
@@ -25,30 +25,27 @@ Alternatively, run the [run.sh](run.sh) bash script which contains this command.
 
 ## Configuration
 
-### Get the generated password
+1. Get the generated password
+ - `docker logs mysql1 2>&1 | grep GENERATED` = $GENERATED_PASSWORD
 
-`docker logs mysql1 2>&1 | grep GENERATED`
+1. Log in to mysql with the generated password
+ - `docker exec -it mysql1 mysql -uroot -p$GENERATED_PASSWORD`
 
-### Log in to mysql with the generated password
+1. Update the root user password to _password_
+ - `UPDATE mysql.user SET Password=PASSWORD('password') WHERE User='root';`
 
-`docker exec -it mysql1 mysql -uroot -p%GENERATED_PASSWORD%`
+1. Restart the container
+ - `docker restart mysql1`
 
-### Update the root user password to _password_
-
-`UPDATE mysql.user SET Password=PASSWORD('password') WHERE User='root';`
-
-### Restart the container
-
-`docker restart mysql1`
-
-### Log in to mysql again with the new password (_password_)
-
-`docker exec -it mysql1 mysql -uroot -ppassword`
+1. Log in to mysql again with the new password (_password_)
+ - `docker exec -it mysql1 mysql -uroot -ppassword`
 
 ## Case sensitivity per operating system
+
 Database and table names __are not__ case sensitive in Windows, and case sensitive in most varieties of Unix.
 
-#### Configure the database to ignore case sensitivity on table names
+### Configure the database to ignore case sensitivity on table names
+
 The `lower_case_table_names` system variable determines if case sensitivity is enabled.  You can check the current value by running this query:
 - `show variables where Variable_name='lower_case_table_names'`
 
@@ -57,7 +54,23 @@ There are three possible values for this:
 - __1__ - Table names are stored in lowercase on disk and name comparisons are not case sensitive.
 - __2__ - lettercase specified in the CREATE TABLE or CREATE DATABASE statement, but MySQL converts them to lowercase on lookup. Name comparisons are not case sensitive.
 
-#### Update the configuration file
+#### Dockerfile instruction support
+
+The Dockerfile has an instruction to copy the configuration file to the file system to enable the case insensitivity
+`COPY my.cnf /etc/mysql/my.cnf`
+
+#### Check the _lower_case_table_names_ system variable
+
+Run this `mysqladmin` command on the docker container:
+ - `docker exec mysql1 mysqladmin -uroot -ppassword variables | grep lower_case_table_names`
+
+The result should be:
+- `| lower_case_table_names | 1 |`
+
+
+----
+
+#### OPTIONAL - Manually update the configuration file
 
 1. connect to the container `docker exec -it mysql1 bash`
 1. Locate file at /etc/mysql/my.cnf

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+lower_case_table_names=1


### PR DESCRIPTION
This change adds the COPY instruction to the Dockerfile so that case
insensitivity is enabled when the Docker image is built.
The _my.cnf_ configuration file, and the relevant updates to the
README.md file are also included.