### PR TITLE
Add steps to create a new vanilla image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM mysql/mysql-server:5.5
+RUN  yum install -y vim
 COPY my.cnf /etc/mysql/my.cnf


### PR DESCRIPTION
Vim is now installed on docker build, and steps to specify a default
root password are shown in the README.